### PR TITLE
readstream mapper end method and test fixes

### DIFF
--- a/util/src/main/java/org/folio/reservoir/util/readstream/Mapper.java
+++ b/util/src/main/java/org/folio/reservoir/util/readstream/Mapper.java
@@ -14,11 +14,14 @@ public interface Mapper<T, V> {
   public void push(T item);
 
   /**
-   * Retreive the last mapped element. If the element is not ready, 'null' is returned.
-   * Note that the poll(true) can be called multiple times
-   * @param ended true indicates that there will be no more push calls.
+   * Retrieve the last mapped element. If the element is not ready, 'null' is returned.
    * @return mapped element
    */
-  public V poll(boolean ended);
-  
+  public V poll();
+
+  /**
+   * End-of-elements; push not called again.
+   */
+  public void end();
+
 }

--- a/util/src/main/java/org/folio/reservoir/util/readstream/MappingReadStream.java
+++ b/util/src/main/java/org/folio/reservoir/util/readstream/MappingReadStream.java
@@ -84,6 +84,7 @@ public class MappingReadStream<T,V> implements ReadStream<T>, Handler<V> {
       throw new IllegalStateException("Parsing already done");
     }
     ended = true;
+    mapper.end();
     checkPending();
   }
 
@@ -100,7 +101,7 @@ public class MappingReadStream<T,V> implements ReadStream<T>, Handler<V> {
     emitting = true;
     try {
       while (demand > 0L) {
-        T t = mapper.poll(ended);
+        T t = mapper.poll();
         if (t == null) {
           break;
         }

--- a/util/src/main/java/org/folio/reservoir/util/readstream/Marc4jMapper.java
+++ b/util/src/main/java/org/folio/reservoir/util/readstream/Marc4jMapper.java
@@ -12,6 +12,9 @@ import org.marc4j.marc.Record;
 
 public class Marc4jMapper implements Mapper<Buffer, Record> {
   private Buffer pendingBuffer = Buffer.buffer();
+
+  private boolean ended;
+
   MarcReader marcReader;
 
   /**
@@ -49,7 +52,7 @@ public class Marc4jMapper implements Mapper<Buffer, Record> {
   }
 
   @Override
-  public Record poll(boolean ended) {
+  public Record poll() {
     if (marcReader != null) {
       if (marcReader.hasNext()) {
         return marcReader.next();
@@ -82,6 +85,11 @@ public class Marc4jMapper implements Mapper<Buffer, Record> {
   @Override
   public void push(Buffer buffer) {
     this.pendingBuffer.appendBuffer(buffer);
+  }
+
+  @Override
+  public void end() {
+    ended = true;
   }
 
 }

--- a/util/src/main/java/org/folio/reservoir/util/readstream/MarcJsonToIngestMapper.java
+++ b/util/src/main/java/org/folio/reservoir/util/readstream/MarcJsonToIngestMapper.java
@@ -14,6 +14,8 @@ import org.folio.reservoir.util.MarcInJsonUtil;
  */
 public class MarcJsonToIngestMapper implements Mapper<JsonObject, JsonObject> {
 
+  private boolean ended;
+
   List<JsonObject> marc = new LinkedList<>();
 
   @Override
@@ -45,7 +47,7 @@ public class MarcJsonToIngestMapper implements Mapper<JsonObject, JsonObject> {
   // S:5413 'List.remove()' should not be used in ascending 'for' loops
   @java.lang.SuppressWarnings({"squid:S5413"})
   @Override
-  public JsonObject poll(boolean ended) {
+  public JsonObject poll() {
     if (marc.isEmpty()) {
       return null;
     }
@@ -83,5 +85,10 @@ public class MarcJsonToIngestMapper implements Mapper<JsonObject, JsonObject> {
       payload.put("marcHoldings", holdings);
     }
     return globalRecord;
+  }
+
+  @Override
+  public void end() {
+    ended = true;
   }
 }

--- a/util/src/main/java/org/folio/reservoir/util/readstream/MarcToJsonMapper.java
+++ b/util/src/main/java/org/folio/reservoir/util/readstream/MarcToJsonMapper.java
@@ -8,7 +8,7 @@ import org.marc4j.MarcJsonWriter;
 import org.marc4j.marc.Record;
 
 public class MarcToJsonMapper implements Mapper<Record, JsonObject> {
-  
+
   List<JsonObject> items = new LinkedList<>();
   ByteArrayOutputStream buffer = new ByteArrayOutputStream();
   MarcJsonWriter writer = new MarcJsonWriter(buffer);
@@ -22,11 +22,15 @@ public class MarcToJsonMapper implements Mapper<Record, JsonObject> {
   }
 
   @Override
-  public JsonObject poll(boolean ended) {
+  public JsonObject poll() {
     if (items.isEmpty()) {
       return null;
     }
     return items.remove(0);
   }
-  
+
+  @Override
+  public void end() {
+    // no special end marker (whole items)
+  }
 }

--- a/util/src/main/java/org/folio/reservoir/util/readstream/XmlMapper.java
+++ b/util/src/main/java/org/folio/reservoir/util/readstream/XmlMapper.java
@@ -9,6 +9,9 @@ import io.vertx.core.json.DecodeException;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
+/**
+ * Stream mapper based on <a href="https://github.com/FasterXML/aalto-xml">Aalto XML</a>.
+ */
 public class XmlMapper
     implements Mapper<Buffer, XMLStreamReader> {
   private final AsyncXMLStreamReader<AsyncByteArrayFeeder> parser;
@@ -19,11 +22,8 @@ public class XmlMapper
   }
 
   @Override
-  public XMLStreamReader poll(boolean ended) {
+  public XMLStreamReader poll() {
     try {
-      if (ended) {
-        parser.getInputFeeder().endOfInput();
-      }
       if (parser.hasNext() && parser.next() != AsyncXMLStreamReader.EVENT_INCOMPLETE) {
         return parser;
       }
@@ -31,6 +31,11 @@ public class XmlMapper
     } catch (XMLStreamException e) {
       throw new DecodeException(e.getMessage(), e);
     }
+  }
+
+  @Override
+  public void end() {
+    parser.getInputFeeder().endOfInput();
   }
 
   @Override

--- a/util/src/test/java/org/folio/reservoir/util/readstream/XmlParserTest.java
+++ b/util/src/test/java/org/folio/reservoir/util/readstream/XmlParserTest.java
@@ -3,20 +3,22 @@ package org.folio.reservoir.util.readstream;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
+import io.vertx.core.buffer.Buffer;
 import io.vertx.core.file.OpenOptions;
+import io.vertx.core.json.DecodeException;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.folio.reservoir.util.readstream.XmlParser;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import javax.xml.stream.XMLStreamConstants;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
@@ -58,6 +60,17 @@ public class XmlParserTest {
     eventsFromFile("record10.xml").onComplete(context.asyncAssertSuccess(events -> {
       assertThat(events, hasSize(2965));
     }));
+  }
+
+  @Test
+  public void feedInputThrowsException() {
+    XmlMapper xmlMapper = new XmlMapper();
+    xmlMapper.push(Buffer.buffer("<"));
+    xmlMapper.end();
+    // we are violating the contract by using push after end
+    Exception e = Assert.assertThrows(DecodeException.class,
+        () -> xmlMapper.push(Buffer.buffer("xml/>")));
+    assertThat(e.getMessage(), is("Still have 1 unread bytes"));
   }
 
   @Test

--- a/util/src/test/java/org/folio/reservoir/util/readstream/XmlParserTest.java
+++ b/util/src/test/java/org/folio/reservoir/util/readstream/XmlParserTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
@@ -176,17 +177,17 @@ public class XmlParserTest {
     xmlParserFromFile("small.xml")
         .compose(xmlParser -> {
           Promise<Void> promise = Promise.promise();
-          xmlParser.handler(null);
-          xmlParser.handler(event -> events.add(event.getEventType()));
+          xmlParser.handler(event -> {
+            events.add(event.getEventType());
+            if (events.size() == 4) {
+              promise.tryComplete();
+            }
+          });
           xmlParser.exceptionHandler(promise::tryFail);
           xmlParser.pause();
-          vertx.setTimer(50, x1 -> {
+          vertx.setTimer(5, x1 -> {
             assertThat(events, empty());
             xmlParser.resume();
-            vertx.setTimer(50, x2 -> {
-              assertThat(events, hasSize(4));
-              promise.complete();
-            });
           });
           return promise.future();
         })

--- a/util/src/test/java/org/folio/reservoir/util/readstream/XmlParserTest.java
+++ b/util/src/test/java/org/folio/reservoir/util/readstream/XmlParserTest.java
@@ -23,7 +23,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 

--- a/util/src/test/java/org/folio/reservoir/util/readstream/XmlParserTest.java
+++ b/util/src/test/java/org/folio/reservoir/util/readstream/XmlParserTest.java
@@ -67,9 +67,9 @@ public class XmlParserTest {
     XmlMapper xmlMapper = new XmlMapper();
     xmlMapper.push(Buffer.buffer("<"));
     xmlMapper.end();
+    Buffer xml2 = Buffer.buffer("xml/>");
     // we are violating the contract by using push after end
-    Exception e = Assert.assertThrows(DecodeException.class,
-        () -> xmlMapper.push(Buffer.buffer("xml/>")));
+    Exception e = Assert.assertThrows(DecodeException.class, () -> xmlMapper.push(xml2));
     assertThat(e.getMessage(), is("Still have 1 unread bytes"));
   }
 


### PR DESCRIPTION
This simplifies poll and ensures end-of-stream is signalled even if poll is not called.