### PR TITLE
Fix xmlFixer maps unicode chars to replacement RSRVR-116

### DIFF
--- a/util/src/main/java/org/folio/reservoir/util/readstream/XmlFixerMapper.java
+++ b/util/src/main/java/org/folio/reservoir/util/readstream/XmlFixerMapper.java
@@ -34,7 +34,8 @@ public class XmlFixerMapper implements Mapper<Buffer, Buffer> {
     tail = 0;
     for (front = 0; front < input.length(); front++) {
       byte leadingByte = input.getByte(front);
-      if (leadingByte < 32 && leadingByte != 9 && leadingByte != 10 && leadingByte != 13) {
+      if (leadingByte > 0 && leadingByte < 32
+          && leadingByte != 9 && leadingByte != 10 && leadingByte != 13) {
         result.appendBuffer(input, tail, front - tail);
         addFix();
       } else if (leadingByte == '&' && handleEntity(input)) {

--- a/util/src/test/java/org/folio/reservoir/util/readstream/XmlFixerMapperTest.java
+++ b/util/src/test/java/org/folio/reservoir/util/readstream/XmlFixerMapperTest.java
@@ -53,9 +53,9 @@ public class XmlFixerMapperTest {
   public void testSingleCharBad() {
     XmlFixerMapper xmlFixerMapper = new XmlFixerMapper();
 
-    xmlFixerMapper.push(Buffer.buffer("\t\r\n\f \n"));
+    xmlFixerMapper.push(Buffer.buffer("\t\r\n\f \nJerzy Borzęcki."));
     Buffer poll = xmlFixerMapper.poll();
-    assertThat(poll.toString(), is("\t\r\n&#xFFFD; \n"));
+    assertThat(poll.toString(), is("\t\r\n&#xFFFD; \nJerzy Borzęcki."));
     poll = xmlFixerMapper.poll();
     assertThat(poll, is(nullValue()));
 


### PR DESCRIPTION
Should read the manual: byte = signed char afterall :-)