### PR TITLE
XmlMapper: own exception and handle incomplete XML

### DIFF
--- a/server/src/test/java/org/folio/reservoir/server/MainVerticleTest.java
+++ b/server/src/test/java/org/folio/reservoir/server/MainVerticleTest.java
@@ -4033,7 +4033,7 @@ public class MainVerticleTest extends TestBase {
         .body("items[0].status", is("idle"))
         .body("items[0].totalRecords", is(0))
         .body("items[0].totalRequests", is(1))
-        .body("items[0].error", is(nullValue())) // error should be reported
+        .body("items[0].error", containsString("Incomplete input"))
         .body("items[0].config.id", is(PMH_CLIENT_ID))
         .body("items[0].config.sourceId", is(SOURCE_ID_1));
   }

--- a/util/src/main/java/org/folio/reservoir/util/readstream/XmlMapperException.java
+++ b/util/src/main/java/org/folio/reservoir/util/readstream/XmlMapperException.java
@@ -1,6 +1,5 @@
 package org.folio.reservoir.util.readstream;
 
-import javax.xml.stream.Location;
 import javax.xml.stream.XMLStreamException;
 
 public class XmlMapperException extends RuntimeException {

--- a/util/src/main/java/org/folio/reservoir/util/readstream/XmlMapperException.java
+++ b/util/src/main/java/org/folio/reservoir/util/readstream/XmlMapperException.java
@@ -1,0 +1,11 @@
+package org.folio.reservoir.util.readstream;
+
+import javax.xml.stream.Location;
+import javax.xml.stream.XMLStreamException;
+
+public class XmlMapperException extends RuntimeException {
+
+  public XmlMapperException(XMLStreamException e) {
+    super(e.getMessage(), e);
+  }
+}


### PR DESCRIPTION
Throw XmlMapperException rather than DecodeException. Throw XmlMapperException for incomplete input. The underlying parser aalto-xml does not.