### PR TITLE
RSRVR-127 lenient matchkeys goldrush

### DIFF
--- a/js/matchkeys/goldrush/goldrush.mjs
+++ b/js/matchkeys/goldrush/goldrush.mjs
@@ -8,11 +8,6 @@ function loadMarcJson(record) {
   if (!Array.isArray(marcObj.fields)) {
     throw new Error('MARC fields is not an array.');
   }
-  const field0 = Object.keys(marcObj.fields[0]);
-  const re = /^\d+$/;
-  if (!re.test(field0)) {
-    throw new Error('MARC fields[0] key is not numeric.');
-  }
   if (!marcObj.leader) {
     marcObj.leader = '00000nam a22000000a 4500';
   }


### PR DESCRIPTION
[RSRVR-127](https://issues.folio.org/browse/RSRVR-127)

Remove the test for field0 tag to allow invalid MARC records to still be processed.