### PR TITLE
RSRVR-134: GraalVM 24.1.1, json-path 2.9.0 fixing vulns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <graalvm.version>22.3.2</graalvm.version>
+    <!-- graalvm >= 23.1.0 requires reorganisation: https://medium.com/graalvm/truffle-unchained-13887b77b62c -->
+    <graalvm.version>23.0.6</graalvm.version>
     <log4j2.version>2.19.0</log4j2.version>
     <vertx.version>4.5.11</vertx.version>
     <okapi.version>5.1.2</okapi.version>
@@ -115,7 +116,7 @@
       <dependency>
         <groupId>com.jayway.jsonpath</groupId>
         <artifactId>json-path</artifactId>
-        <version>2.8.0</version>
+        <version>2.9.0</version>
       </dependency>
       <dependency>
         <groupId>io.rest-assured</groupId>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/RSRVR-134

Upgrade graalvm from 22.3.2 to 24.1.1 fixing many security vulnerabilities:

* https://security.snyk.io/package/maven/org.graalvm.sdk:graal-sdk

Upgrade json-path from 2.8.0 to 2.9.0 fixing a security vulnerability:

* https://security.snyk.io/package/maven/com.jayway.jsonpath:json-path